### PR TITLE
fix: toast message when copying server entry for a Streamable HTTP transport URL

### DIFF
--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -175,7 +175,9 @@ const Sidebar = ({
             description:
               transportType === "stdio"
                 ? "Server configuration has been copied to clipboard. Add this to your mcp.json inside the 'mcpServers' object with your preferred server name."
-                : "SSE URL has been copied. Use this URL directly in your MCP Client.",
+                : transportType === "streamable-http"
+                  ? "Streamable HTTP URL has been copied. Use this URL directly in your MCP Client."
+                  : "SSE URL has been copied. Use this URL directly in your MCP Client.",
           });
 
           setTimeout(() => {

--- a/client/src/components/__tests__/Sidebar.test.tsx
+++ b/client/src/components/__tests__/Sidebar.test.tsx
@@ -446,6 +446,11 @@ describe("Sidebar", () => {
         4,
       );
       expect(mockClipboardWrite).toHaveBeenCalledWith(expectedConfig);
+      expect(mockToast).toHaveBeenCalledWith({
+        title: "Config entry copied",
+        description:
+          "Server configuration has been copied to clipboard. Add this to your mcp.json inside the 'mcpServers' object with your preferred server name.",
+      });
     });
 
     it("should copy servers file configuration to clipboard for STDIO transport", async () => {
@@ -504,6 +509,11 @@ describe("Sidebar", () => {
         4,
       );
       expect(mockClipboardWrite).toHaveBeenCalledWith(expectedConfig);
+      expect(mockToast).toHaveBeenCalledWith({
+        title: "Config entry copied",
+        description:
+          "SSE URL has been copied. Use this URL directly in your MCP Client.",
+      });
     });
 
     it("should copy servers file configuration to clipboard for SSE transport", async () => {
@@ -554,6 +564,11 @@ describe("Sidebar", () => {
         4,
       );
       expect(mockClipboardWrite).toHaveBeenCalledWith(expectedConfig);
+      expect(mockToast).toHaveBeenCalledWith({
+        title: "Config entry copied",
+        description:
+          "Streamable HTTP URL has been copied. Use this URL directly in your MCP Client.",
+      });
     });
 
     it("should copy servers file configuration to clipboard for streamable-http transport", async () => {


### PR DESCRIPTION
## Summary
- handle streamable-http transport in config entry toast
- test toast messages for all transport types
- clarify toast to say "Streamable HTTP URL"

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bcfaae9a08832390163512aecd10ea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Transport-aware toast messages when copying Server Entry: distinct descriptions for STDIO, SSE, and Streamable HTTP to clarify how to use the copied value.
- Tests
  - Updated tests to assert transport-specific toast descriptions for Server Entry copies.
  - Confirmed identical title across transports and no toast for servers file copies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->